### PR TITLE
Benchmark script and removed unused eval in HTTP:Headers::Fast

### DIFF
--- a/lib/HTTP/Headers/Fast.pm
+++ b/lib/HTTP/Headers/Fast.pm
@@ -7,13 +7,6 @@ use Carp ();
 our $VERSION = '0.18';
 our $TRANSLATE_UNDERSCORE = 1;
 
-eval {
-    require XSLoader;
-    XSLoader::load( 'HTTP::Headers::Fast::XS', $VERSION );
-    *_standardize_field_name =
-        *HTTP::Headers::Fast::XS::_standardize_field_name;
-};
-
 # "Good Practice" order of HTTP message headers:
 #    - General-Headers
 #    - Request-Headers

--- a/tools/xs-benchmark.pl
+++ b/tools/xs-benchmark.pl
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use Dumbbench;
+use Getopt::Long;
+
+use HTTP::Headers::Fast;
+
+my %cases = (
+    _standardize_field_name => sub {
+        my ($instance, $iterations) =  @_;
+        for (1..$iterations) {
+            HTTP::Headers::Fast::_standardize_field_name('X-Foo');
+        };
+    },
+    push_header => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->push_header("X-Foo" => "Bar");
+        }
+    },
+    get_header => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        $headers->header("X-Foo", 1);
+        for (1..$iterations) {
+            $headers->header("X-Foo");
+        }
+    },
+);
+
+my $iterations   = 1e4;
+my $initial_runs = 25;
+my $verbose      = 0;
+my $cases;
+
+GetOptions ("iterations=i"   => \$iterations,   
+            "initial_runs=i" => \$initial_runs,
+            "verbose"        => \$verbose,
+            "cases=s"        => \$cases,
+    ) or die("Error in command line arguments\n");
+
+my @run_cases = sort keys %cases;
+if ($cases){
+    @run_cases = split ',', $cases; 
+}
+
+my $bench   = execute_benchmark(\@run_cases);
+
+# enable the XS functions
+require HTTP::Headers::Fast::XS;
+
+my $xs_bench = execute_benchmark(\@run_cases);
+
+my @instances    = $bench->instances;
+my @xs_instances = $xs_bench->instances;
+
+foreach my $case_index (0..$#run_cases){
+    my $case      = $run_cases[$case_index];
+    my $original  = $instances[$case_index]->{result}{num};
+    my $xs        = $xs_instances[$case_index]->{result}{num};
+
+    $bench->report if $verbose;
+    $xs_bench->report if $verbose;
+    # speedup
+    printf("%-30s -- %.2f\n", $case, $original / $xs);
+}
+
+sub execute_benchmark {
+    my $run_cases = shift;
+
+    my $bench = Dumbbench->new(
+        target_rel_precision => 0.005, # seek ~0.5%
+        verbosity            => $verbose,
+        initial_runs         => $initial_runs,
+    );
+
+    foreach my $case (@$run_cases){
+        $bench->add_instances(
+            Dumbbench::Instance::PerlSub->new(code => sub {
+                my $original = HTTP::Headers::Fast->new();
+                $cases{$case}->($original, $iterations);
+            })
+        );
+    }
+    $bench->run();
+    return $bench;   
+}

--- a/tools/xs-benchmark.pl
+++ b/tools/xs-benchmark.pl
@@ -22,12 +22,69 @@ my %cases = (
             $headers->push_header("X-Foo" => "Bar");
         }
     },
+    push_header_many => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->push_header("X-Foo" => "Bar", "X-Bar" => 2, "X-Baz" => 3);
+        }
+    },
+    get_date => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        $headers->date(1226370757);
+        for (1..$iterations) {
+            $headers->date;
+        }
+    },
+    set_date => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->date(1226370757);
+        }
+    },
+    scan => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->scan();
+        }
+    },
     get_header => sub {
         my ($instance, $iterations) = @_;
         my $headers = HTTP::Headers::Fast->new();
         $headers->header("X-Foo", 1);
         for (1..$iterations) {
             $headers->header("X-Foo");
+        }
+    },
+    set_header => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->header("Content-Length", 10);
+        }
+    },
+    get_content_length => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->content_length;
+        }
+    },
+    as_string_without_sort => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->as_string_without_sort;
+        }
+    },
+    as_string => sub {
+        my ($instance, $iterations) = @_;
+        my $headers = HTTP::Headers::Fast->new();
+        for (1..$iterations) {
+            $headers->as_string;
         }
     },
 );
@@ -37,7 +94,7 @@ my $initial_runs = 25;
 my $verbose      = 0;
 my $cases;
 
-GetOptions ("iterations=i"   => \$iterations,   
+GetOptions ("iterations=i"   => \$iterations,
             "initial_runs=i" => \$initial_runs,
             "verbose"        => \$verbose,
             "cases=s"        => \$cases,
@@ -45,7 +102,7 @@ GetOptions ("iterations=i"   => \$iterations,
 
 my @run_cases = sort keys %cases;
 if ($cases){
-    @run_cases = split ',', $cases; 
+    @run_cases = split ',', $cases;
 }
 
 my $bench   = execute_benchmark(\@run_cases);
@@ -57,14 +114,14 @@ my $xs_bench = execute_benchmark(\@run_cases);
 
 my @instances    = $bench->instances;
 my @xs_instances = $xs_bench->instances;
+$bench->report if $verbose;
+$xs_bench->report if $verbose;
 
 foreach my $case_index (0..$#run_cases){
     my $case      = $run_cases[$case_index];
     my $original  = $instances[$case_index]->{result}{num};
     my $xs        = $xs_instances[$case_index]->{result}{num};
 
-    $bench->report if $verbose;
-    $xs_bench->report if $verbose;
     # speedup
     printf("%-30s -- %.2f\n", $case, $original / $xs);
 }
@@ -87,5 +144,5 @@ sub execute_benchmark {
         );
     }
     $bench->run();
-    return $bench;   
+    return $bench;
 }


### PR DESCRIPTION
We don't need the eval inside HTTP:Headers::Fast because the same thing
is executed when loading HTTP::Headers::Fast:XS.

Added a script to compare the XS and the original versions of the
module. Example usage:

```
$ perl -I ./blib/arch/ -I ./blib/lib/ ./tools/xs-benchmark.pl -v
```

or if you want to run the benchmark only for one test case:

```
$ perl -I ./blib/arch/ -I ./blib/lib/ ./tools/xs-benchmark.pl -v -c _standardize_field_name
```
